### PR TITLE
Fixing undefined error

### DIFF
--- a/src/StripeCheckout.vue
+++ b/src/StripeCheckout.vue
@@ -78,7 +78,9 @@
                     .catch(e => console.error(e));
 
             window.addEventListener('popstate', function () {
-                this.stripe.close();
+                if (typeof this.stripe !== 'undefined') {
+                    this.stripe.close();
+                }
             });
         },
         methods: {


### PR DESCRIPTION
Fixing error when triggering popstate before stripe is ready.

When using this component and other components / scripts are triggering a popstate, it throws undefined errors:

````Uncaught TypeError: Cannot read property 'close' of undefined````

In my case, I have embedded the component in a form with tabs, and using `window.location.hash` and `popstate` to remember tav navigation.